### PR TITLE
Updated TimeLineSettings to Use since_id

### DIFF
--- a/oAuthTwitterWrapper/App.config
+++ b/oAuthTwitterWrapper/App.config
@@ -4,7 +4,7 @@
     <add key="oAuthConsumerKey" value="Key"/>
     <add key="oAuthConsumerSecret" value="Secret"/>
     <add key="oAuthUrl" value="https://api.twitter.com/oauth2/token"/>
-    <add key="timelineFormat" value="https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name={0}&amp;include_rts={1}&amp;exclude_replies={2}&amp;count={3}&amp;since_id={4}"/>
+    <add key="timelineFormat" value="https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name={0}&amp;include_rts={1}&amp;exclude_replies={2}&amp;count={3}"/>
     <add key="timeline_since_id" value="0"/>
     <add key="screenname" value="screenname"/>
     <add key="include_rts" value="1"/>

--- a/oAuthTwitterWrapper/App.config
+++ b/oAuthTwitterWrapper/App.config
@@ -4,7 +4,8 @@
     <add key="oAuthConsumerKey" value="Key"/>
     <add key="oAuthConsumerSecret" value="Secret"/>
     <add key="oAuthUrl" value="https://api.twitter.com/oauth2/token"/>
-    <add key="timelineFormat" value="https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name={0}&amp;include_rts={1}&amp;exclude_replies={2}&amp;count={3}"/>
+    <add key="timelineFormat" value="https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name={0}&amp;include_rts={1}&amp;exclude_replies={2}&amp;count={3}&amp;since_id={4}"/>
+    <add key="timeline_since_id" value="0"/>
     <add key="screenname" value="screenname"/>
     <add key="include_rts" value="1"/>
     <add key="exclude_replies" value="0"/>

--- a/oAuthTwitterWrapper/ITimeLineSettings.cs
+++ b/oAuthTwitterWrapper/ITimeLineSettings.cs
@@ -8,5 +8,6 @@ namespace OAuthTwitterWrapper
 		string ScreenName { get; set; }
 		string TimelineFormat { get; set; }
 		string TimelineUrl { get; }
+        string Since_ID { get; set; }
 	}
 }

--- a/oAuthTwitterWrapper/OAuthTwitterWrapper.cs
+++ b/oAuthTwitterWrapper/OAuthTwitterWrapper.cs
@@ -31,14 +31,16 @@ namespace OAuthTwitterWrapper
 			string include_rts = ConfigurationManager.AppSettings["include_rts"];
 			string exclude_replies = ConfigurationManager.AppSettings["exclude_replies"];
 			int count = Convert.ToInt16(ConfigurationManager.AppSettings["count"]);
-			string timelineFormat = ConfigurationManager.AppSettings["timelineFormat"];			
+			string timelineFormat = ConfigurationManager.AppSettings["timelineFormat"];
+            string since_id = ConfigurationManager.AppSettings["timeline_since_id"];
 			TimeLineSettings = new TimeLineSettings
 			{
 				ScreenName = screenname,
 				IncludeRts = include_rts,
 				ExcludeReplies = exclude_replies,
 				Count = count,
-				TimelineFormat = timelineFormat
+				TimelineFormat = timelineFormat,
+                Since_ID = since_id
 			};
 			string searchFormat = ConfigurationManager.AppSettings["searchFormat"];
 			string searchQuery = ConfigurationManager.AppSettings["searchQuery"];

--- a/oAuthTwitterWrapper/TimeLineSettings.cs
+++ b/oAuthTwitterWrapper/TimeLineSettings.cs
@@ -17,7 +17,15 @@ namespace OAuthTwitterWrapper
 		{
 			get
 			{
-				return string.Format(TimelineFormat, ScreenName, IncludeRts, ExcludeReplies, Count,Since_ID);
+                if (Since_ID != "0")
+                {
+                    return string.Format(TimelineFormat, ScreenName, IncludeRts, ExcludeReplies, Count);
+                }
+                else
+                {
+                    return string.Format(TimelineFormat + "&amp;since_id={4}", ScreenName, IncludeRts, ExcludeReplies, Count, Since_ID);
+                }
+				
 			}
 		}
 	}

--- a/oAuthTwitterWrapper/TimeLineSettings.cs
+++ b/oAuthTwitterWrapper/TimeLineSettings.cs
@@ -12,11 +12,12 @@ namespace OAuthTwitterWrapper
 		public string ExcludeReplies { get; set; }
 		public int Count { get; set; }
 		public string TimelineFormat { get; set; }
+        public string Since_ID { get; set; }
 		public string TimelineUrl
 		{
 			get
 			{
-				return string.Format(TimelineFormat, ScreenName, IncludeRts, ExcludeReplies, Count);
+				return string.Format(TimelineFormat, ScreenName, IncludeRts, ExcludeReplies, Count,Since_ID);
 			}
 		}
 	}


### PR DESCRIPTION
Per our discussion, I updated the timeline settings to take since_id.  This will allow me to provide a minimum/since "tweet" id that I want to get data from.  

The suggestion you had made to update searchsettings wouldn't have worked since per your comment earlier Twitter API doesn't allow one to search based on user for that you have to use timeline and timeline doesn't provide a way to get Tweets based on date, you have to use since_id.

Look it over and let me know what you think. 

Dhaval
